### PR TITLE
Added support for autolayout and refactored internal code.

### DIFF
--- a/JSCustomBadge/JSCustomBadge.h
+++ b/JSCustomBadge/JSCustomBadge.h
@@ -33,20 +33,75 @@
 
 @interface JSCustomBadge : UIView
 
+/**
+ *  The content that the badge should display. Any time this property is set, an internal call will be made to render the new value.
+ *  One can also just call updateBadgeContentWithString method if they would rather use bracket syntax rather than dot syntax.
+ */
 @property (strong, nonatomic) NSString *badgeText;
+
+/**
+ *  Indicates what the badge text color should be, by default it is white.
+ */
 @property (strong, nonatomic) UIColor *badgeTextColor;
+
+/**
+ *  Indicates what the fill color of the badge should be, by default the color is iOS 7 red.
+ */
 @property (strong, nonatomic) UIColor *badgeInsetColor;
+
+/**
+ *  Indicates what the fill color of the border of the badge should be.
+ */
 @property (strong, nonatomic) UIColor *badgeFrameColor;
 
+/**
+ *  Indicates if the badge should have a border around itself.
+ */
 @property (assign, nonatomic) BOOL badgeFrame;
+
+/**
+ *  Indicates if a shine should be on the badge.
+ */
 @property (assign, nonatomic) BOOL badgeShining;
+
+/**
+ *  Indicates if a shadow should be on the badge.
+ */
 @property (assign, nonatomic) BOOL badgeShadow;
 
+/**
+ *  The sharpness of our corners. Default is set at 0.4f
+ */
 @property (assign, nonatomic) CGFloat badgeCornerRoundness;
+
+/**
+ *  The scale factor that should be used. By default the factor is 1. The default size is set at 25 points.
+ */
 @property (assign, nonatomic) CGFloat badgeScaleFactor;
 
+/**
+ *  Intializies a badge with a specific string.
+ *
+ *  @param badgeString The specific string to set the badge text value to initially.
+ *
+ *  @return A valid JSCustomBadge instance.
+ */
 + (JSCustomBadge *)customBadgeWithString:(NSString *)badgeString;
 
+/**
+ *  Intializies a customized badge.
+ *
+ *  @param badgeString     The specific string to set the badge text value to initially.
+ *  @param stringColor     The color the text should be.
+ *  @param insetColor      The fill color for the badge
+ *  @param badgeFrameYesNo A frame wrapped, border, around the badge.
+ *  @param frameColor      The color the border of the badge should be.
+ *  @param scale           A scale factor that is a multiple of the default content size of 25.0f points.
+ *  @param shining         Adds a shine to the badge.
+ *  @param shadow          Adds a shadow to the badge.
+ *
+ *  @return A valid JSCustomBadge instance.
+ */
 + (JSCustomBadge *)customBadgeWithString:(NSString *)badgeString
                          withStringColor:(UIColor*)stringColor
                           withInsetColor:(UIColor*)insetColor
@@ -56,7 +111,11 @@
                              withShining:(BOOL)shining
                               withShadow:(BOOL)shadow;
 
-// Use to change the badge text after the first rendering
+/**
+ *  Use to change the badge text after the first rendering
+ *
+ *  @param badgeString The string to display in the badge.
+ */
 - (void)autoBadgeSizeWithString:(NSString *)badgeString;
 
 @end

--- a/JSCustomBadge/JSCustomBadge.m
+++ b/JSCustomBadge/JSCustomBadge.m
@@ -218,14 +218,14 @@ static CGFloat const IC_QUARTERFACTOR = 0.25f;
 {
     CGContextRef context = UIGraphicsGetCurrentContext();
     
-	[self drawRoundedRectWithContext:context inRect:rect];
+	[self drawRoundedRectWithContext:context inRect:self.bounds];
 	
 	if (self.badgeShining) {
-		[self drawShineWithContext:context inRect:rect];
+		[self drawShineWithContext:context inRect:self.bounds];
     }
 	
 	if (self.badgeFrame) {
-		[self drawFrameWithContext:context inRect:rect];
+		[self drawFrameWithContext:context inRect:self.bounds];
     }
 	
 	if ([self.badgeText length] > 0.0f) {
@@ -244,10 +244,10 @@ static CGFloat const IC_QUARTERFACTOR = 0.25f;
         NSStringDrawingContext *drawingContext = [[NSStringDrawingContext alloc] init];
         drawingContext.minimumScaleFactor = 0.5;
         
-        [self.badgeText drawWithRect:CGRectMake(rect.size.width / 2.0f - textSize.width / 2.0f,
-                                                rect.size.height / 2.0f - textSize.height / 2.0f,
-                                                rect.size.width,
-                                                rect.size.height)
+        [self.badgeText drawWithRect:CGRectMake(self.bounds.size.width / 2.0f - textSize.width / 2.0f,
+                                                self.bounds.size.height / 2.0f - textSize.height / 2.0f,
+                                                self.bounds.size.width,
+                                                self.bounds.size.height)
                              options:NSStringDrawingUsesLineFragmentOrigin
                           attributes:textAttributes
                              context:drawingContext];

--- a/JSCustomBadge/JSCustomBadge.m
+++ b/JSCustomBadge/JSCustomBadge.m
@@ -31,8 +31,8 @@
 
 #import "JSCustomBadge.h"
 
-static CGFloat const IC_DEFUALTCONTENTSIZE = 25.0f;
-static CGFloat const IC_DEFUALTCORNERROUNDNESS = 0.4f;
+static CGFloat const IC_DEFAULTCONTENTSIZE = 25.0f;
+static CGFloat const IC_DEFAULTCORNERROUNDNESS = 0.4f;
 static CGFloat const IC_DEFAULTSCALEFACTOR = 1.0f;
 static CGFloat const IC_QUARTERFACTOR = 0.25f;
 
@@ -47,52 +47,35 @@ static CGFloat const IC_QUARTERFACTOR = 0.25f;
 
 @implementation JSCustomBadge
 
-@synthesize badgeText = _badgeText;
-
 #pragma mark - Initialization
 
 - (void)dealloc
 {
-    self.badgeText = nil;
-    self.badgeTextColor = nil;
-    self.badgeInsetColor = nil;
-    self.badgeFrameColor = nil;
     [self removeObserver:self forKeyPath:NSStringFromSelector(@selector(badgeText))];
     [self removeObserver:self forKeyPath:NSStringFromSelector(@selector(contentSize))];
 }
 
 - (void)awakeFromNib
 {
-    self.contentSize = CGSizeMake(IC_DEFUALTCONTENTSIZE, IC_DEFUALTCONTENTSIZE);
-}
-
-- (instancetype)initWithCoder:(NSCoder *)aDecoder
-{
-    self = [super initWithCoder:aDecoder];
-    
-    if (self)
-    {
-        [self addObserver:self forKeyPath:NSStringFromSelector(@selector(badgeText)) options:0 context:nil];
-        [self addObserver:self forKeyPath:NSStringFromSelector(@selector(contentSize)) options:0 context:nil];
-        self.contentScaleFactor = [[UIScreen mainScreen] scale];
-		self.backgroundColor = [UIColor clearColor];
-		self.badgeTextColor = [UIColor whiteColor];
-		self.badgeFrame = NO;
-		self.badgeFrameColor = nil;
-		self.badgeInsetColor =  [UIColor colorWithRed:1.0f green:0.22f blue:0.22f alpha:1.0f]; // iOS 7 red
-		self.badgeCornerRoundness = IC_DEFUALTCORNERROUNDNESS;
-		self.badgeScaleFactor = IC_DEFAULTSCALEFACTOR;
-		self.badgeShining = NO;
-        self.badgeShadow = NO;
-        self.badgeText = @"";
-    }
-    
-    return self;
+    self.contentSize = CGSizeMake(IC_DEFAULTCONTENTSIZE, IC_DEFAULTCONTENTSIZE);
+    [self addObserver:self forKeyPath:NSStringFromSelector(@selector(badgeText)) options:0 context:nil];
+    [self addObserver:self forKeyPath:NSStringFromSelector(@selector(contentSize)) options:0 context:nil];
+    self.contentScaleFactor = [[UIScreen mainScreen] scale];
+    self.backgroundColor = [UIColor clearColor];
+    self.badgeTextColor = [UIColor whiteColor];
+    self.badgeFrame = NO;
+    self.badgeFrameColor = nil;
+    self.badgeInsetColor =  [UIColor colorWithRed:1.0f green:0.22f blue:0.22f alpha:1.0f]; // iOS 7 red
+    self.badgeCornerRoundness = IC_DEFAULTCORNERROUNDNESS;
+    self.badgeScaleFactor = IC_DEFAULTSCALEFACTOR;
+    self.badgeShining = NO;
+    self.badgeShadow = NO;
+    self.badgeText = @"";
 }
 
 - (instancetype)initWithString:(NSString *)badgeString withScale:(CGFloat)scale withShining:(BOOL)shining
 {
-	self = [super initWithFrame:CGRectMake(0.0f, 0.0f, IC_DEFUALTCONTENTSIZE, IC_DEFUALTCONTENTSIZE)];
+	self = [super initWithFrame:CGRectMake(0.0f, 0.0f, IC_DEFAULTCONTENTSIZE, IC_DEFAULTCONTENTSIZE)];
     
 	if (self)
     {
@@ -104,7 +87,7 @@ static CGFloat const IC_QUARTERFACTOR = 0.25f;
 		self.badgeFrame = NO;
 		self.badgeFrameColor = nil;
 		self.badgeInsetColor =  [UIColor colorWithRed:1.0f green:0.22f blue:0.22f alpha:1.0f]; // iOS 7 red
-		self.badgeCornerRoundness = IC_DEFUALTCORNERROUNDNESS;
+		self.badgeCornerRoundness = IC_DEFAULTCORNERROUNDNESS;
 		self.badgeScaleFactor = scale;
 		self.badgeShining = shining;
         self.badgeShadow = NO;
@@ -123,7 +106,7 @@ static CGFloat const IC_QUARTERFACTOR = 0.25f;
                    withShining:(BOOL)shining
                     withShadow:(BOOL)shadow
 {
-	self = [super initWithFrame:CGRectMake(0.0f, 0.0f, IC_DEFUALTCONTENTSIZE, IC_DEFUALTCONTENTSIZE)];
+	self = [super initWithFrame:CGRectMake(0.0f, 0.0f, IC_DEFAULTCONTENTSIZE, IC_DEFAULTCONTENTSIZE)];
     
 	if (self)
     {
@@ -135,7 +118,7 @@ static CGFloat const IC_QUARTERFACTOR = 0.25f;
 		self.badgeFrame = badgeFrameYesNo;
 		self.badgeFrameColor = frameColor;
 		self.badgeInsetColor = insetColor;
-		self.badgeCornerRoundness = IC_DEFUALTCORNERROUNDNESS;
+		self.badgeCornerRoundness = IC_DEFAULTCORNERROUNDNESS;
 		self.badgeScaleFactor = scale;
 		self.badgeShining = shining;
         self.badgeShadow = shadow;
@@ -217,11 +200,11 @@ static CGFloat const IC_QUARTERFACTOR = 0.25f;
 	
     if ([badgeString length] >= 2.0f) {
 		flexSpace = [badgeString length];
-		rectWidth = IC_DEFUALTCONTENTSIZE + (stringSize.width + flexSpace); rectHeight = IC_DEFUALTCONTENTSIZE;
+		rectWidth = IC_DEFAULTCONTENTSIZE + (stringSize.width + flexSpace); rectHeight = IC_DEFAULTCONTENTSIZE;
 		retValue = CGSizeMake(rectWidth * self.badgeScaleFactor, rectHeight * self.badgeScaleFactor);
 	}
     else {
-		retValue = CGSizeMake(IC_DEFUALTCONTENTSIZE * self.badgeScaleFactor, IC_DEFUALTCONTENTSIZE * self.badgeScaleFactor);
+		retValue = CGSizeMake(IC_DEFAULTCONTENTSIZE * self.badgeScaleFactor, IC_DEFAULTCONTENTSIZE * self.badgeScaleFactor);
 	}
 	
     _badgeText = badgeString;

--- a/JSCustomBadge/JSCustomBadge.m
+++ b/JSCustomBadge/JSCustomBadge.m
@@ -31,105 +31,135 @@
 
 #import "JSCustomBadge.h"
 
-@interface JSCustomBadge()
+static CGFloat const IC_DEFUALTCONTENTSIZE = 25.0f;
+static CGFloat const IC_DEFUALTCORNERROUNDNESS = 0.4f;
+static CGFloat const IC_DEFAULTSCALEFACTOR = 1.0f;
+static CGFloat const IC_QUARTERFACTOR = 0.25f;
 
-- (id)initWithString:(NSString *)badgeString withScale:(CGFloat)scale withShining:(BOOL)shining;
+@interface JSCustomBadge ()
 
-- (id)initWithString:(NSString *)badgeString
-     withStringColor:(UIColor *)stringColor
-      withInsetColor:(UIColor *)insetColor
-      withBadgeFrame:(BOOL)badgeFrameYesNo
- withBadgeFrameColor:(UIColor *)frameColor
-           withScale:(CGFloat)scale
-         withShining:(BOOL)shining
-          withShadow:(BOOL)shadow;
-
-- (void)drawRoundedRectWithContext:(CGContextRef)context inRect:(CGRect)rect;
-- (void)drawShineWithContext:(CGContextRef)context inRect:(CGRect)rect;
-- (void)drawFrameWithContext:(CGContextRef)context inRect:(CGRect)rect;
+/**
+ *  Represents the view's size internally. Once set, intrinsic content size is invalidated and Autolayout will ask our view's for its intrinsic content size.
+ */
+@property (assign, nonatomic) CGSize contentSize;
 
 @end
 
-
-
 @implementation JSCustomBadge
+
+@synthesize badgeText = _badgeText;
 
 #pragma mark - Initialization
 
-- (id)initWithString:(NSString *)badgeString withScale:(CGFloat)scale withShining:(BOOL)shining
-{
-	self = [super initWithFrame:CGRectMake(0.0f, 0.0f, 25.0f, 25.0f)];
-    
-	if(self) {
-		self.contentScaleFactor = [[UIScreen mainScreen] scale];
-		self.backgroundColor = [UIColor clearColor];
-		_badgeText = badgeString;
-		_badgeTextColor = [UIColor whiteColor];
-		_badgeFrame = NO;
-		_badgeFrameColor = nil;
-		_badgeInsetColor =  [UIColor colorWithRed:1.0f green:0.22f blue:0.22f alpha:1.0f]; // iOS 7 red
-		_badgeCornerRoundness = 0.4f;
-		_badgeScaleFactor = scale;
-		_badgeShining = shining;
-        _badgeShadow = NO;
-		[self autoBadgeSizeWithString:badgeString];		
-	}
-    
-	return self;
-}
-
-- (id)initWithString:(NSString *)badgeString
-     withStringColor:(UIColor *)stringColor
-      withInsetColor:(UIColor *)insetColor
-      withBadgeFrame:(BOOL)badgeFrameYesNo
- withBadgeFrameColor:(UIColor *)frameColor
-           withScale:(CGFloat)scale
-         withShining:(BOOL)shining
-          withShadow:(BOOL)shadow
-{
-	self = [super initWithFrame:CGRectMake(0.0f, 0.0f, 25.0f, 25.0f)];
-    
-	if(self) {
-		self.contentScaleFactor = [[UIScreen mainScreen] scale];
-		self.backgroundColor = [UIColor clearColor];
-		_badgeText = badgeString;
-		_badgeTextColor = stringColor;
-		_badgeFrame = badgeFrameYesNo;
-		_badgeFrameColor = frameColor;
-		_badgeInsetColor = insetColor;
-		_badgeCornerRoundness = 0.4f;
-		_badgeScaleFactor = scale;
-		_badgeShining = shining;
-        _badgeShadow = shadow;
-		[self autoBadgeSizeWithString:badgeString];
-	}
-    
-	return self;
-}
-
 - (void)dealloc
 {
-    _badgeText = nil;
-    _badgeTextColor = nil;
-    _badgeInsetColor = nil;
-    _badgeFrameColor = nil;
+    self.badgeText = nil;
+    self.badgeTextColor = nil;
+    self.badgeInsetColor = nil;
+    self.badgeFrameColor = nil;
+    [self removeObserver:self forKeyPath:NSStringFromSelector(@selector(badgeText))];
+    [self removeObserver:self forKeyPath:NSStringFromSelector(@selector(contentSize))];
+}
+
+- (void)awakeFromNib
+{
+    self.contentSize = CGSizeMake(IC_DEFUALTCONTENTSIZE, IC_DEFUALTCONTENTSIZE);
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    
+    if (self)
+    {
+        [self addObserver:self forKeyPath:NSStringFromSelector(@selector(badgeText)) options:0 context:nil];
+        [self addObserver:self forKeyPath:NSStringFromSelector(@selector(contentSize)) options:0 context:nil];
+        self.contentScaleFactor = [[UIScreen mainScreen] scale];
+		self.backgroundColor = [UIColor clearColor];
+		self.badgeTextColor = [UIColor whiteColor];
+		self.badgeFrame = NO;
+		self.badgeFrameColor = nil;
+		self.badgeInsetColor =  [UIColor colorWithRed:1.0f green:0.22f blue:0.22f alpha:1.0f]; // iOS 7 red
+		self.badgeCornerRoundness = IC_DEFUALTCORNERROUNDNESS;
+		self.badgeScaleFactor = IC_DEFAULTSCALEFACTOR;
+		self.badgeShining = NO;
+        self.badgeShadow = NO;
+        self.badgeText = @"";
+    }
+    
+    return self;
+}
+
+- (instancetype)initWithString:(NSString *)badgeString withScale:(CGFloat)scale withShining:(BOOL)shining
+{
+	self = [super initWithFrame:CGRectMake(0.0f, 0.0f, IC_DEFUALTCONTENTSIZE, IC_DEFUALTCONTENTSIZE)];
+    
+	if (self)
+    {
+        [self addObserver:self forKeyPath:NSStringFromSelector(@selector(badgeText)) options:0 context:nil];
+        [self addObserver:self forKeyPath:NSStringFromSelector(@selector(contentSize)) options:0 context:nil];
+		self.contentScaleFactor = [[UIScreen mainScreen] scale];
+		self.backgroundColor = [UIColor clearColor];
+		self.badgeTextColor = [UIColor whiteColor];
+		self.badgeFrame = NO;
+		self.badgeFrameColor = nil;
+		self.badgeInsetColor =  [UIColor colorWithRed:1.0f green:0.22f blue:0.22f alpha:1.0f]; // iOS 7 red
+		self.badgeCornerRoundness = IC_DEFUALTCORNERROUNDNESS;
+		self.badgeScaleFactor = scale;
+		self.badgeShining = shining;
+        self.badgeShadow = NO;
+        self.badgeText = badgeString;
+	}
+    
+	return self;
+}
+
+- (instancetype)initWithString:(NSString *)badgeString
+               withStringColor:(UIColor *)stringColor
+                withInsetColor:(UIColor *)insetColor
+                withBadgeFrame:(BOOL)badgeFrameYesNo
+           withBadgeFrameColor:(UIColor *)frameColor
+                     withScale:(CGFloat)scale
+                   withShining:(BOOL)shining
+                    withShadow:(BOOL)shadow
+{
+	self = [super initWithFrame:CGRectMake(0.0f, 0.0f, IC_DEFUALTCONTENTSIZE, IC_DEFUALTCONTENTSIZE)];
+    
+	if (self)
+    {
+        [self addObserver:self forKeyPath:NSStringFromSelector(@selector(badgeText)) options:0 context:nil];
+        [self addObserver:self forKeyPath:NSStringFromSelector(@selector(contentSize)) options:0 context:nil];
+		self.contentScaleFactor = [[UIScreen mainScreen] scale];
+		self.backgroundColor = [UIColor clearColor];
+		self.badgeTextColor = stringColor;
+		self.badgeFrame = badgeFrameYesNo;
+		self.badgeFrameColor = frameColor;
+		self.badgeInsetColor = insetColor;
+		self.badgeCornerRoundness = IC_DEFUALTCORNERROUNDNESS;
+		self.badgeScaleFactor = scale;
+		self.badgeShining = shining;
+        self.badgeShadow = shadow;
+        self.badgeText = badgeString;
+	}
+    
+	return self;
 }
 
 #pragma mark - Class initializers
 
-+ (JSCustomBadge *) customBadgeWithString:(NSString *)badgeString
++ (JSCustomBadge *)customBadgeWithString:(NSString *)badgeString
 {
 	return [[JSCustomBadge alloc] initWithString:badgeString withScale:1.0f withShining:NO];
 }
 
-+ (JSCustomBadge *) customBadgeWithString:(NSString *)badgeString
-                          withStringColor:(UIColor *)stringColor
-                           withInsetColor:(UIColor *)insetColor
-                           withBadgeFrame:(BOOL)badgeFrameYesNo
-                      withBadgeFrameColor:(UIColor *)frameColor
-                                withScale:(CGFloat)scale
-                              withShining:(BOOL)shining
-                               withShadow:(BOOL)shadow
++ (JSCustomBadge *)customBadgeWithString:(NSString *)badgeString
+                         withStringColor:(UIColor *)stringColor
+                          withInsetColor:(UIColor *)insetColor
+                          withBadgeFrame:(BOOL)badgeFrameYesNo
+                     withBadgeFrameColor:(UIColor *)frameColor
+                               withScale:(CGFloat)scale
+                             withShining:(BOOL)shining
+                              withShadow:(BOOL)shadow
 {
 	return [[JSCustomBadge alloc] initWithString:badgeString
                                  withStringColor:stringColor
@@ -141,31 +171,65 @@
                                       withShadow:shadow];
 }
 
+#pragma mark - Autolayout Support
+
+- (CGSize)intrinsicContentSize
+{
+    return self.contentSize;
+}
+
+- (void)updateContentSize:(CGSize)contentSize
+{
+    // Sets our internal content size property and once set our internal listener will receive notification and tell invalidate the intrinsic content size.
+    self.contentSize = contentSize;
+    
+    // Set our frame for non-Autolayout support. If we are on Autolayout, the system will over ride our set and so this setthing of the frame should be harmless.
+    self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, contentSize.width, contentSize.height);
+}
+
+#pragma mark - Observation
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    if (object == self && [keyPath isEqualToString:NSStringFromSelector(@selector(contentSize))])
+    {
+        // Tell Autolayout that our current intrinsic content size is no longer valid.
+        [self invalidateIntrinsicContentSize];
+    }
+    else if (object == self && [keyPath isEqualToString:NSStringFromSelector(@selector(badgeText))])
+    {
+        [self autoBadgeSizeWithString:self.badgeText];
+    }
+    else
+    {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    }
+}
+
 #pragma mark - Utilities
 
 - (void)autoBadgeSizeWithString:(NSString *)badgeString
 {
 	CGSize retValue;
 	CGFloat rectWidth, rectHeight;
-	CGSize stringSize = [badgeString sizeWithFont:[UIFont boldSystemFontOfSize:12.0f]];
+	CGSize stringSize = [badgeString sizeWithAttributes:@{ NSFontAttributeName : [UIFont boldSystemFontOfSize:12.0f] }];
 	CGFloat flexSpace;
 	
-    if([badgeString length] >= 2.0f) {
+    if ([badgeString length] >= 2.0f) {
 		flexSpace = [badgeString length];
-		rectWidth = 25.0f + (stringSize.width + flexSpace); rectHeight = 25.0f;
-		retValue = CGSizeMake(rectWidth * _badgeScaleFactor, rectHeight * _badgeScaleFactor);
+		rectWidth = IC_DEFUALTCONTENTSIZE + (stringSize.width + flexSpace); rectHeight = IC_DEFUALTCONTENTSIZE;
+		retValue = CGSizeMake(rectWidth * self.badgeScaleFactor, rectHeight * self.badgeScaleFactor);
 	}
     else {
-		retValue = CGSizeMake(25.0f * _badgeScaleFactor, 25.0f * _badgeScaleFactor);
+		retValue = CGSizeMake(IC_DEFUALTCONTENTSIZE * self.badgeScaleFactor, IC_DEFUALTCONTENTSIZE * self.badgeScaleFactor);
 	}
 	
-    self.frame = CGRectMake(self.frame.origin.x, self.frame.origin.y, retValue.width, retValue.height);
-	_badgeText = badgeString;
-	
+    _badgeText = badgeString;
+    [self updateContentSize:retValue];
     [self setNeedsDisplay];
 }
 
-#pragma mark - Drawing
+#pragma mark - Drawing Methods
 
 - (void)drawRect:(CGRect)rect
 {
@@ -173,27 +237,37 @@
     
 	[self drawRoundedRectWithContext:context inRect:rect];
 	
-	if(self.badgeShining)
+	if (self.badgeShining) {
 		[self drawShineWithContext:context inRect:rect];
+    }
 	
-	if(self.badgeFrame)
+	if (self.badgeFrame) {
 		[self drawFrameWithContext:context inRect:rect];
+    }
 	
-	if([self.badgeText length] > 0.0f) {
+	if ([self.badgeText length] > 0.0f) {
         
 		[self.badgeTextColor set];
 		CGFloat sizeOfFont = 13.5f * self.badgeScaleFactor;
 		
-        if([self.badgeText length] < 2.0f) {
+        if ([self.badgeText length] < 2.0f) {
 			sizeOfFont += sizeOfFont * 0.2f;
 		}
         
 		UIFont *textFont = [UIFont boldSystemFontOfSize:sizeOfFont];
-		CGSize textSize = [self.badgeText sizeWithFont:textFont];
+        NSDictionary *textAttributes = @{ NSFontAttributeName : textFont, NSForegroundColorAttributeName : self.badgeTextColor };
+		CGSize textSize = [self.badgeText sizeWithAttributes:textAttributes];
 		
-        [self.badgeText drawAtPoint:CGPointMake((rect.size.width/2.0f - textSize.width/2.0f),
-                                                (rect.size.height/2.0f - textSize.height/2.0f))
-                           withFont:textFont];
+        NSStringDrawingContext *drawingContext = [[NSStringDrawingContext alloc] init];
+        drawingContext.minimumScaleFactor = 0.5;
+        
+        [self.badgeText drawWithRect:CGRectMake(rect.size.width / 2.0f - textSize.width / 2.0f,
+                                                rect.size.height / 2.0f - textSize.height / 2.0f,
+                                                rect.size.width,
+                                                rect.size.height)
+                             options:NSStringDrawingUsesLineFragmentOrigin
+                          attributes:textAttributes
+                             context:drawingContext];
 	}
 }
 
@@ -207,30 +281,30 @@
 	CGFloat maxY = CGRectGetMaxY(rect) - puffer;
 	CGFloat minX = CGRectGetMinX(rect) + puffer;
 	CGFloat minY = CGRectGetMinY(rect) + puffer;
-		
+    
     CGContextBeginPath(context);
 	CGContextSetFillColorWithColor(context, [self.badgeInsetColor CGColor]);
 	CGContextAddArc(context, maxX-radius, minY+radius, radius, M_PI+(M_PI/2.0f), 0.0f, 0.0f);
 	CGContextAddArc(context, maxX-radius, maxY-radius, radius, 0.0f, M_PI/2.0f, 0.0f);
 	CGContextAddArc(context, minX+radius, maxY-radius, radius, M_PI/2.0f, M_PI, 0.0f);
 	CGContextAddArc(context, minX+radius, minY+radius, radius, M_PI, M_PI+M_PI/2.0f, 0.0f);
-
-    if(self.badgeShadow) {
+    
+    if (self.badgeShadow) {
         CGContextSetShadowWithColor(context,
                                     CGSizeMake(0.0f, 1.0f),
                                     2.0f,
                                     [UIColor colorWithWhite:0.0f alpha:0.75f].CGColor);
     }
-
+    
     CGContextFillPath(context);
-
+    
 	CGContextRestoreGState(context);
 }
 
 - (void)drawShineWithContext:(CGContextRef)context inRect:(CGRect)rect
 {
 	CGContextSaveGState(context);
- 
+    
 	CGFloat radius = CGRectGetMaxY(rect) * self.badgeCornerRoundness;
 	CGFloat puffer = CGRectGetMaxY(rect) * 0.1f;
 	CGFloat maxX = CGRectGetMaxX(rect) - puffer;
@@ -248,7 +322,7 @@
 	size_t num_locations = 2.0f;
 	CGFloat locations[2] = { 0.0f, 0.4f };
 	CGFloat components[8] = { 0.92f, 0.92f, 0.92f, 1.0f, 0.82f, 0.82f, 0.82f, 0.4f };
-
+    
 	CGColorSpaceRef cspace;
 	CGGradientRef gradient;
 	cspace = CGColorSpaceCreateDeviceRGB();
@@ -259,12 +333,12 @@
 	sPoint.y = 0.0f;
 	ePoint.x = 0.0f;
 	ePoint.y = maxY;
-	CGContextDrawLinearGradient (context, gradient, sPoint, ePoint, 0.0f);
+	CGContextDrawLinearGradient(context, gradient, sPoint, ePoint, 0.0f);
 	
 	CGColorSpaceRelease(cspace);
 	CGGradientRelease(gradient);
 	
-	CGContextRestoreGState(context);	
+	CGContextRestoreGState(context);
 }
 
 - (void)drawFrameWithContext:(CGContextRef)context inRect:(CGRect)rect
@@ -280,8 +354,8 @@
     CGContextBeginPath(context);
 	CGFloat lineSize = 2.0f;
     
-	if(self.badgeScaleFactor > 1.0f) {
-		lineSize += self.badgeScaleFactor * 0.25f;
+	if (self.badgeScaleFactor > IC_DEFAULTSCALEFACTOR) {
+		lineSize += self.badgeScaleFactor * IC_QUARTERFACTOR;
 	}
     
 	CGContextSetLineWidth(context, lineSize);


### PR DESCRIPTION
We've made some updates to the badge for use in our own software.
- Added documentation comments to public methods (which will show in XCode 5+).
- Updated badge to handle auto-layout better.  It now has its own intrinsicContentSize which auto-layout will respect.
- Fixed issues with partial drawing of the badge when UIKit decides to invalidate only a part of the drawing rectangle.
-  Support for being added into `.xib` and `.storyboard` files.  Still can't edit properties of these in Interface Builder, but you can at least place them and setup constraints.
- Updated to not use deprecated methods in iOS 7 like `sizeWithFont:` and `drawAtPoint:`.
